### PR TITLE
av fixes

### DIFF
--- a/media/libmedia/MediaProfiles.cpp
+++ b/media/libmedia/MediaProfiles.cpp
@@ -975,7 +975,8 @@ MediaProfiles::getInstance()
                     property_get("ro.board.platform", platform, NULL);
                     if (!strcmp(platform, "msm8953")){
                         if (property_get("vendor.media.target.version", value, "0") &&
-                            (atoi(value) == 1)){
+                            (atoi(value) == 1) &&
+                            checkXmlFile("/vendor/etc/media_profiles_8953_v1.xml")){
                             strlcpy(value, "/vendor/etc/media_profiles_8953_v1.xml",
                                     PROPERTY_VALUE_MAX);
                         } else {
@@ -984,7 +985,8 @@ MediaProfiles::getInstance()
                         }
                     } else if (!strcmp(platform, "sdm660")) {
                         property_get("vendor.media.target.version", value, "0");
-                        if (atoi(value) == 1) {
+                        if (atoi(value) == 1 &&
+                                checkXmlFile("/vendor/etc/media_profiles_sdm660_v1.xml")) {
                             strlcpy(value, "/vendor/etc/media_profiles_sdm660_v1.xml",
                                     PROPERTY_VALUE_MAX);
                         } else {
@@ -993,10 +995,12 @@ MediaProfiles::getInstance()
                         }
                     } else if (!strcmp(platform, "bengal")) {
                         property_get("vendor.sys.media.target.version", value, "0");
-                        if (atoi(value) == 3) {
+                        if (atoi(value) == 3 &&
+                                checkXmlFile("/vendor/etc/media_profiles_khaje.xml")) {
                             strlcpy(value, "/vendor/etc/media_profiles_khaje.xml",
                                     PROPERTY_VALUE_MAX);
-                        } else if (atoi(value) == 2) {
+                        } else if (atoi(value) == 2 &&
+                                checkXmlFile("/vendor/etc/media_profiles_scuba.xml")) {
                             strlcpy(value, "/vendor/etc/media_profiles_scuba.xml",
                                     PROPERTY_VALUE_MAX);
                         } else {
@@ -1008,8 +1012,10 @@ MediaProfiles::getInstance()
                     if (property_get("ro.media.xml_variant.codecs", variant, NULL) > 0) {
                         std::string xmlPath = std::string("/vendor/etc/media_profiles") +
                                               std::string(variant) + std::string(".xml");
-                        strlcpy(value, xmlPath.c_str(), PROPERTY_VALUE_MAX);
-                        ALOGI("Profiles xml path: %s", value);
+                        if (checkXmlFile(xmlPath.c_str())) {
+                            strlcpy(value, xmlPath.c_str(), PROPERTY_VALUE_MAX);
+                            ALOGI("Profiles xml path: %s", value);
+                        }
                     }
                 }
             sInstance = createInstanceFromXmlFile(value);

--- a/media/libmedia/MediaProfiles.cpp
+++ b/media/libmedia/MediaProfiles.cpp
@@ -950,6 +950,7 @@ void MediaProfiles::checkAndAddRequiredProfilesIfNecessary() {
 /*static*/ MediaProfiles*
 MediaProfiles::getInstance()
 {
+    char platform[PROPERTY_VALUE_MAX] = {0};
     ALOGV("getInstance");
     Mutex::Autolock lock(sLock);
     if (!sIsInitialized) {
@@ -970,6 +971,47 @@ MediaProfiles::getInstance()
                 sInstance = createInstanceFromXmlFile(xmlFile);
             }
         } else {
+                if (!strncmp(value, "/vendor/etc", strlen("/vendor/etc"))) {
+                    property_get("ro.board.platform", platform, NULL);
+                    if (!strcmp(platform, "msm8953")){
+                        if (property_get("vendor.media.target.version", value, "0") &&
+                            (atoi(value) == 1)){
+                            strlcpy(value, "/vendor/etc/media_profiles_8953_v1.xml",
+                                    PROPERTY_VALUE_MAX);
+                        } else {
+                            strlcpy(value, "/vendor/etc/media_profiles_vendor.xml",
+                                    PROPERTY_VALUE_MAX);
+                        }
+                    } else if (!strcmp(platform, "sdm660")) {
+                        property_get("vendor.media.target.version", value, "0");
+                        if (atoi(value) == 1) {
+                            strlcpy(value, "/vendor/etc/media_profiles_sdm660_v1.xml",
+                                    PROPERTY_VALUE_MAX);
+                        } else {
+                            strlcpy(value, "/vendor/etc/media_profiles_vendor.xml",
+                                    PROPERTY_VALUE_MAX);
+                        }
+                    } else if (!strcmp(platform, "bengal")) {
+                        property_get("vendor.sys.media.target.version", value, "0");
+                        if (atoi(value) == 3) {
+                            strlcpy(value, "/vendor/etc/media_profiles_khaje.xml",
+                                    PROPERTY_VALUE_MAX);
+                        } else if (atoi(value) == 2) {
+                            strlcpy(value, "/vendor/etc/media_profiles_scuba.xml",
+                                    PROPERTY_VALUE_MAX);
+                        } else {
+                            strlcpy(value, "/vendor/etc/media_profiles_vendor.xml",
+                                    PROPERTY_VALUE_MAX);
+                        }
+                    }
+                    char variant[PROPERTY_VALUE_MAX];
+                    if (property_get("ro.media.xml_variant.codecs", variant, NULL) > 0) {
+                        std::string xmlPath = std::string("/vendor/etc/media_profiles") +
+                                              std::string(variant) + std::string(".xml");
+                        strlcpy(value, xmlPath.c_str(), PROPERTY_VALUE_MAX);
+                        ALOGI("Profiles xml path: %s", value);
+                    }
+                }
             sInstance = createInstanceFromXmlFile(value);
         }
         CHECK(sInstance != NULL);

--- a/media/libstagefright/xmlparser/Android.bp
+++ b/media/libstagefright/xmlparser/Android.bp
@@ -34,7 +34,14 @@ cc_library_shared {
         "libexpat",
         "liblog",
         "libstagefright_omx_utils",
+        "libcutils"
     ],
+
+    target: {
+        vendor: {
+            cflags: ["-D__ANDROID_VNDK__"],
+        },
+    },
 
     cflags: [
         "-Werror",

--- a/media/libstagefright/xmlparser/MediaCodecsXmlParser.cpp
+++ b/media/libstagefright/xmlparser/MediaCodecsXmlParser.cpp
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-//#define LOG_NDEBUG 0
+#define LOG_NDEBUG 0
+#define PROP_VALUE_MAX 92
 #define LOG_TAG "MediaCodecsXmlParser"
 
 #include <media/stagefright/xmlparser/MediaCodecsXmlParser.h>
@@ -39,6 +40,7 @@
 #include <algorithm>
 #include <cctype>
 #include <string>
+#include <cutils/properties.h>
 
 namespace android {
 
@@ -118,6 +120,57 @@ status_t combineStatus(status_t a, status_t b) {
         // prefer the first error result
         return a ? : b;
     }
+}
+
+std::string getVendorXmlPath(const std::string &path) {
+    std::string vendorPath;
+    std::string result = path;
+
+    if (!strncmp(path.c_str(), "/vendor/etc/media_codecs.xml",
+                    strlen("/vendor/etc/media_codecs.xml"))) {
+        vendorPath = "/vendor/etc/media_codecs_vendor";
+    } else if (!strncmp(path.c_str(), "/vendor/etc/media_codecs_performance.xml",
+                    strlen("/vendor/etc/media_codecs_performance.xml"))) {
+        vendorPath = "/vendor/etc/media_codecs_performance";
+    }
+
+    if (!vendorPath.empty()) {
+        if (fileExists(vendorPath + std::string(".xml"))) {
+            char version[PROP_VALUE_MAX] = {0};
+            result = vendorPath + std::string(".xml");
+#ifdef __ANDROID_VNDK__
+            property_get("vendor.media.target.version", version, "0");
+#else
+            property_get("vendor.sys.media.target.version", version, "0");
+#endif
+            if (atoi(version) > 0) {
+                std::string versionedXml = vendorPath + std::string("_v") +
+                                 std::string(version) + std::string(".xml");
+                if(fileExists(versionedXml)) {
+                    result = versionedXml;
+                }
+            }
+        }
+        ALOGI("getVendorXmlPath (%s)", result.c_str());
+    }
+
+    // Choose different xmls based on system (if needed)
+    if (!android::base::GetProperty("ro.media.xml_variant.codecs", "").empty()){
+        const std::vector<std::string> &xmlFiles = MediaCodecsXmlParser::getDefaultXmlNames();
+        for (const std::string &xmlName : xmlFiles) {
+            vendorPath = "/vendor/etc/" + xmlName;
+            if (!strncmp(path.c_str(), vendorPath.c_str(), vendorPath.size())) {
+                vendorPath = vendorPath.substr(0,vendorPath.size()-4) + "_vendor.xml";
+                if (fileExists(vendorPath)) {
+                    result = vendorPath;
+                }
+                ALOGI("getVendorXmlPath %s", result.c_str());
+                break;
+            }
+        }
+    }
+
+    return result;
 }
 
 MediaCodecsXmlParser::StringSet parseCommaSeparatedStringSet(const char *s) {
@@ -445,20 +498,22 @@ status_t MediaCodecsXmlParser::Impl::parseXmlFilesInSearchDirs(
 
 status_t MediaCodecsXmlParser::Impl::parseXmlPath(const std::string &path) {
     std::lock_guard<std::mutex> guard(mLock);
-    if (!fileExists(path)) {
-        ALOGV("Cannot find %s", path.c_str());
+    std::string vendorPath = getVendorXmlPath(path);
+
+    if (!fileExists(vendorPath)) {
+        ALOGV("Cannot find %s", vendorPath.c_str());
         mParsingStatus = combineStatus(mParsingStatus, NAME_NOT_FOUND);
         return NAME_NOT_FOUND;
     }
 
     // save state (even though we should always be at toplevel here)
     State::RestorePoint rp = mState.createRestorePoint();
-    Parser parser(&mState, path);
+    Parser parser(&mState, vendorPath);
     parser.parseXmlFile();
     mState.restore(rp);
 
     if (parser.getStatus() != OK) {
-        ALOGD("parseXmlPath(%s) failed with %s", path.c_str(), asString(parser.getStatus()));
+        ALOGD("parseXmlPath(%s) failed with %s", vendorPath.c_str(), asString(parser.getStatus()));
     }
     mParsingStatus = combineStatus(mParsingStatus, parser.getStatus());
     return parser.getStatus();


### PR DESCRIPTION
1. This commit for the framework to load vendor encoders and decoders when enabling the vendor media codec service.
For example, on Xiaomi devices, enable the "dolbycodec2" service supports Dolby Vision in Netflix.
3. This commit is a supplement to https://github.com/Evolution-XYZ/frameworks_av/pull/4/commits/64af4b41f7001b7d7eb5d3fb0ac1b6bcd74913a5.