### PR TITLE
CameraProviderManager: ignore torch callbacks for flashless cameras

### DIFF
--- a/services/camera/libcameraservice/common/CameraProviderManager.cpp
+++ b/services/camera/libcameraservice/common/CameraProviderManager.cpp
@@ -3075,6 +3075,9 @@ void CameraProviderManager::ProviderInfo::torchModeStatusChangeInternal(
         std::lock_guard<std::mutex> lock(mLock);
         for (auto& deviceInfo : mDevices) {
             if (deviceInfo->mName == cameraDeviceName) {
+                if (!deviceInfo->hasFlashUnit()) {
+                    return;
+                }
                 ALOGI("Camera device %s torch status is now %s", cameraDeviceName.c_str(),
                         FrameworkTorchStatusToString(newStatus));
                 id = deviceInfo->mId;


### PR DESCRIPTION
Ignore torch status callbacks for known camera devices that do not have a flash unit.

This keeps CameraService from receiving torch updates for cameras that were never added to its torch status map, which avoids repeated log spam for flashless sensors.

Change-Id: I461190cee18b0107f99e69ebfe0e51cffb11990c